### PR TITLE
Updated Makefile to work on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
+UNAME:=$(shell uname -s)
 MAKEPATH:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 NAMESPACE:=rancher-logging-example
 NAME:=$(NAMESPACE)
 
-install: uninstall-example
+install: uninstall
 	helm install -n $(NAMESPACE) --create-namespace $(NAME) $(MAKEPATH)/charts/rancher-logging-example
 
 uninstall:
@@ -12,5 +13,11 @@ uninstall:
 port-forward:
 	kubectl port-forward -n $(NAMESPACE) svc/$(NAMESPACE)-log-output 8080:80
 
-	open-log-output:
-		open http://localhost:8080
+open-log-output:
+ifeq ($(UNAME), Darwin)
+	open http://localhost:8080
+else ifeq ($(UNAME), Linux)
+	xdg-open http://localhost:8080
+else
+	explorer http://localhost:8080
+endif


### PR DESCRIPTION
Makefile given in the repo doesn't work on Linux so I added a platform check to `port-forward` rule and depending on that switched method used to start the webpage and also removed what seems to be a typo on `install` rule. 

I have tested this only on Linux, I am 98% sure this will work on Darwin but I am not so positive on Windows so give it a test before merging.