### PR TITLE
Added JSON return to List Indices and Logs

### DIFF
--- a/log-output/log-output.go
+++ b/log-output/log-output.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"github.com/gorilla/mux"
-	. "github.com/paynejacob/rancher-logging-examples/log-output/pkg/index"
 	"log"
 	"net/http"
+
+	"github.com/gorilla/mux"
+	. "github.com/paynejacob/rancher-logging-examples/log-output/pkg/index"
 )
 
 func main() {

--- a/log-output/pkg/index/index.go
+++ b/log-output/pkg/index/index.go
@@ -1,11 +1,13 @@
 package index
 
-import "time"
+import (
+	"time"
+)
 
 const MaxIndexLogs = 100
 
 type Index struct {
-	Name     string
+	Name     string    `json:"name"`
 	FirstLog time.Time `json:"first_log"`
 	LastLog  time.Time `json:"last_log"`
 	LogCount int64     `json:"log_count"`
@@ -33,4 +35,3 @@ func WriteLog(index *Index, _log []byte) {
 		index.Logs[index.LogCount-1] = _log
 	}
 }
-


### PR DESCRIPTION
Log output only returned text only `text/html` to both List Indices and List Logs views, Which is ok for humans to read but difficult to machine to parse. As [rancher-logging-explorer]( https://github.com/MrSupiri/rancher-logging-explorer) is using `log-output` service as a dependency it requires to read these data in a more machine-readable format like JSON.

Here is a demo of how it looks like before and after setting `Accept` header

| # | As JSON | As Text |
|-|-|-|
| List Logs | ![List Indices as JSON](https://user-images.githubusercontent.com/29277992/121772967-8f9e9600-cb96-11eb-803e-944624ed72e2.png) | ![List Indices as Text](https://user-images.githubusercontent.com/29277992/121773004-cd032380-cb96-11eb-871f-4138aad17ce4.png) |
| List Indices | ![List Logs as JSON](https://user-images.githubusercontent.com/29277992/121772981-9e854880-cb96-11eb-81c7-485e91b9674b.png) | ![List Logs as Text](https://user-images.githubusercontent.com/29277992/121773013-d7bdb880-cb96-11eb-98b3-e7bbf775262d.png) |